### PR TITLE
🐛 (Makefile): add dependencies update before build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ EXE=ldapproxy
 all: $(EXE)
 
 $(EXE): cmd/*.go
-	cd cmd/ && \
+	cd cmd/ && go mod tidy && \
 	CGO_ENABLED=0 go build && \
 	mv cmd ../$(EXE)
 


### PR DESCRIPTION
Sometimes build could fail because Dependabot PR update dependencies but those must be synced using 'go mod tidy' before build.